### PR TITLE
feat: implement light/dark theme mode with toggle

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'widgets/connection_painter.dart';
 import 'widgets/interactive_connection_widget.dart';
 import 'widgets/connection_endpoint_widget.dart';
 import 'widgets/info_panel_widget.dart';
+import 'theme/app_theme.dart';
 
 void main() {
   runApp(const GraphTodoApp());
@@ -38,14 +39,28 @@ class HomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: const Color(0xFF1A1A1A),
-      body: const CanvasWidget(),
+    return Consumer<CanvasProvider>(
+      builder: (context, provider, child) {
+        return Scaffold(
+          backgroundColor: AppTheme.getBackgroundColor(provider.isDarkMode),
+          body: const CanvasWidget(),
       floatingActionButton: Consumer<CanvasProvider>(
         builder: (context, provider, child) {
           return Column(
             mainAxisSize: MainAxisSize.min,
             children: [
+              // Theme toggle button
+              FloatingActionButton(
+                heroTag: "theme",
+                onPressed: provider.toggleThemeMode,
+                backgroundColor: provider.isDarkMode ? Colors.white : Colors.black87,
+                tooltip: provider.isDarkMode ? 'Light Mode' : 'Dark Mode',
+                child: Icon(
+                  provider.isDarkMode ? Icons.light_mode : Icons.dark_mode,
+                  color: provider.isDarkMode ? Colors.black : Colors.white,
+                ),
+              ),
+              const SizedBox(height: 10),
               // Import button
               FloatingActionButton(
                 heroTag: "import",
@@ -122,6 +137,8 @@ class HomePage extends StatelessWidget {
           );
         },
       ),
+        );
+      },
     );
   }
 
@@ -354,6 +371,7 @@ class _CanvasWidgetState extends State<CanvasWidget> {
                   painter: GridPainter(
                     scale: provider.scale,
                     panOffset: provider.panOffset,
+                    isDarkMode: provider.isDarkMode,
                   ),
                   size: Size.infinite,
                 ),
@@ -365,6 +383,7 @@ class _CanvasWidgetState extends State<CanvasWidget> {
                     nodes: provider.nodes,
                     scale: provider.scale,
                     panOffset: provider.panOffset,
+                    isDarkMode: provider.isDarkMode,
                   ),
                   size: Size.infinite,
                 ),
@@ -442,13 +461,13 @@ class _CanvasWidgetState extends State<CanvasWidget> {
                     child: Container(
                       padding: const EdgeInsets.all(16),
                       decoration: BoxDecoration(
-                        color: Colors.grey.withValues(alpha: 0.9),
+                        color: AppTheme.getModeIndicatorBackground(provider.isDarkMode),
                         borderRadius: BorderRadius.circular(8),
                       ),
-                      child: const Text(
+                      child: Text(
                         'Click anywhere to add a new node',
                         style: TextStyle(
-                          color: Colors.white,
+                          color: AppTheme.getTextColor(provider.isDarkMode),
                           fontWeight: FontWeight.bold,
                         ),
                       ),
@@ -463,7 +482,7 @@ class _CanvasWidgetState extends State<CanvasWidget> {
                     child: Container(
                       padding: const EdgeInsets.all(16),
                       decoration: BoxDecoration(
-                        color: Colors.red.withValues(alpha: 0.9),
+                        color: AppTheme.getModeIndicatorBackground(provider.isDarkMode, isError: true),
                         borderRadius: BorderRadius.circular(8),
                       ),
                       child: const Text(
@@ -484,13 +503,16 @@ class _CanvasWidgetState extends State<CanvasWidget> {
                     child: Container(
                       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                       decoration: BoxDecoration(
-                        color: Colors.black.withValues(alpha: 0.7),
+                        color: provider.isDarkMode
+                          ? Colors.black.withValues(alpha: 0.7)
+                          : Colors.white.withValues(alpha: 0.9),
                         borderRadius: BorderRadius.circular(12),
+                        border: provider.isDarkMode ? null : Border.all(color: AppTheme.lightBorder),
                       ),
-                      child: const Text(
+                      child: Text(
                         'Scroll wheel: zoom • Drag: pan',
                         style: TextStyle(
-                          color: Colors.white,
+                          color: AppTheme.getTextColor(provider.isDarkMode),
                           fontSize: 11,
                         ),
                       ),
@@ -504,13 +526,16 @@ class _CanvasWidgetState extends State<CanvasWidget> {
                   child: Container(
                     padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                     decoration: BoxDecoration(
-                      color: Colors.black.withValues(alpha: 0.7),
+                      color: provider.isDarkMode
+                        ? Colors.black.withValues(alpha: 0.7)
+                        : Colors.white.withValues(alpha: 0.9),
                       borderRadius: BorderRadius.circular(16),
+                      border: provider.isDarkMode ? null : Border.all(color: AppTheme.lightBorder),
                     ),
                     child: Text(
                       '${(provider.scale * 100).toInt()}%',
-                      style: const TextStyle(
-                        color: Colors.white,
+                      style: TextStyle(
+                        color: AppTheme.getTextColor(provider.isDarkMode),
                         fontSize: 12,
                         fontWeight: FontWeight.bold,
                       ),
@@ -532,14 +557,19 @@ class _CanvasWidgetState extends State<CanvasWidget> {
 class GridPainter extends CustomPainter {
   final double scale;
   final Offset panOffset;
+  final bool isDarkMode;
 
-  GridPainter({required this.scale, required this.panOffset});
+  GridPainter({
+    required this.scale,
+    required this.panOffset,
+    required this.isDarkMode,
+  });
 
   @override
   void paint(Canvas canvas, Size size) {
     const gridSize = 50.0;
     final paint = Paint()
-      ..color = Colors.white.withValues(alpha: 0.1)
+      ..color = AppTheme.getGridColor(isDarkMode)
       ..strokeWidth = 1.0;
 
     // Only draw grid if scale is reasonable
@@ -564,6 +594,8 @@ class GridPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(GridPainter oldDelegate) {
-    return scale != oldDelegate.scale || panOffset != oldDelegate.panOffset;
+    return scale != oldDelegate.scale ||
+           panOffset != oldDelegate.panOffset ||
+           isDarkMode != oldDelegate.isDarkMode;
   }
 }

--- a/lib/providers/canvas_provider.dart
+++ b/lib/providers/canvas_provider.dart
@@ -22,7 +22,9 @@ class CanvasProvider with ChangeNotifier {
   String? _newlyCreatedNodeId; // Track newly created node for immediate editing
   String? _nodeShowingInfo; // Track which node is showing info panel
   String? _nodeWithActiveButtons; // Track which node has active action buttons
-  
+
+  // Theme mode
+  bool _isDarkMode = true;
 
   // Getters
   List<TodoNode> get nodes => List.unmodifiable(_nodes);
@@ -38,6 +40,7 @@ class CanvasProvider with ChangeNotifier {
   String? get nodeShowingInfo => _nodeShowingInfo;
   bool get isInfoPanelOpen => _nodeShowingInfo != null;
   String? get nodeWithActiveButtons => _nodeWithActiveButtons;
+  bool get isDarkMode => _isDarkMode;
 
 
   // Add a new node at the given position with immediate editing and zoom
@@ -497,6 +500,12 @@ class CanvasProvider with ChangeNotifier {
     } else {
       _nodeWithActiveButtons = nodeId;
     }
+    notifyListeners();
+  }
+
+  // Toggle theme mode
+  void toggleThemeMode() {
+    _isDarkMode = !_isDarkMode;
     notifyListeners();
   }
 

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -29,6 +29,9 @@ class AppTheme {
   static const Color primaryPurple = Color(0xFF8B5CF6);
   static const Color primaryYellow = Color(0xFFF59E0B);
 
+  // Charcoal color for light mode icons
+  static const Color charcoalIcon = Color(0xFF424242);
+
   // Get colors based on theme mode
   static Color getBackgroundColor(bool isDarkMode) {
     return isDarkMode ? darkBackground : lightBackground;
@@ -128,5 +131,28 @@ class AppTheme {
 
   static Color getIconSelectorHeaderBackground(bool isDarkMode) {
     return isDarkMode ? Colors.black.withValues(alpha: 0.3) : Color(0xFFE8EAF6);
+  }
+
+  // Convert node color to pastel/highlighter version for light mode
+  static Color getNodeBackgroundColor(Color originalColor, bool isDarkMode, {bool isCompleted = false}) {
+    if (isDarkMode) {
+      // Dark mode: keep original colors with high opacity
+      return isCompleted
+        ? originalColor.withValues(alpha: 0.95)
+        : originalColor.withValues(alpha: 0.9);
+    } else {
+      // Light mode: create pastel/highlighter version
+      // Mix with white to create lighter, softer tones
+      final hslColor = HSLColor.fromColor(originalColor);
+      final pastelColor = hslColor.withLightness(0.85).withSaturation(0.6).toColor();
+      return isCompleted
+        ? pastelColor.withValues(alpha: 0.95)
+        : pastelColor.withValues(alpha: 0.9);
+    }
+  }
+
+  // Get icon color for nodes
+  static Color getNodeIconColor(bool isDarkMode) {
+    return isDarkMode ? Colors.white : charcoalIcon;
   }
 }

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+
+class AppTheme {
+  // Dark Theme Colors
+  static const Color darkBackground = Color(0xFF1A1A1A);
+  static const Color darkSurface = Color(0xFF2D2D2D);
+  static const Color darkSurfaceLight = Color(0xFF3A3A3A);
+  static const Color darkBorder = Colors.white24;
+  static const Color darkText = Colors.white;
+  static const Color darkTextSecondary = Colors.white70;
+  static const Color darkTextHint = Colors.white38;
+  static const Color darkGrid = Colors.white10;
+
+  // Light Theme Colors - Very light and minimal
+  static const Color lightBackground = Color(0xFFFAFAFA);
+  static const Color lightSurface = Color(0xFFFFFFFF);
+  static const Color lightSurfaceLight = Color(0xFFF5F5F5);
+  static const Color lightBorder = Color(0xFFE0E0E0);
+  static const Color lightText = Color(0xFF212121);
+  static const Color lightTextSecondary = Color(0xFF616161);
+  static const Color lightTextHint = Color(0xFF9E9E9E);
+  static const Color lightGrid = Color(0xFFEEEEEE);
+
+  // Shared colors
+  static const Color primaryBlue = Color(0xFF3B82F6);
+  static const Color primaryGreen = Color(0xFF4CAF50);
+  static const Color primaryRed = Color(0xFFEF4444);
+  static const Color primaryOrange = Color(0xFFF97316);
+  static const Color primaryPurple = Color(0xFF8B5CF6);
+  static const Color primaryYellow = Color(0xFFF59E0B);
+
+  // Get colors based on theme mode
+  static Color getBackgroundColor(bool isDarkMode) {
+    return isDarkMode ? darkBackground : lightBackground;
+  }
+
+  static Color getSurfaceColor(bool isDarkMode) {
+    return isDarkMode ? darkSurface : lightSurface;
+  }
+
+  static Color getSurfaceLightColor(bool isDarkMode) {
+    return isDarkMode ? darkSurfaceLight : lightSurfaceLight;
+  }
+
+  static Color getBorderColor(bool isDarkMode) {
+    return isDarkMode ? darkBorder : lightBorder;
+  }
+
+  static Color getTextColor(bool isDarkMode) {
+    return isDarkMode ? darkText : lightText;
+  }
+
+  static Color getTextSecondaryColor(bool isDarkMode) {
+    return isDarkMode ? darkTextSecondary : lightTextSecondary;
+  }
+
+  static Color getTextHintColor(bool isDarkMode) {
+    return isDarkMode ? darkTextHint : lightTextHint;
+  }
+
+  static Color getGridColor(bool isDarkMode) {
+    return isDarkMode ? darkGrid : lightGrid;
+  }
+
+  // Connection colors
+  static Color getConnectionColor(bool isDarkMode, {bool isGolden = false}) {
+    if (isGolden) return primaryGreen;
+    return isDarkMode ? Colors.white60 : Color(0xFF757575);
+  }
+
+  static Color getConnectionDotColor(bool isDarkMode, {bool isGolden = false}) {
+    if (isGolden) return primaryGreen;
+    return isDarkMode ? Colors.white70 : Color(0xFF616161);
+  }
+
+  // Selection colors
+  static Color getSelectionColor(bool isDarkMode) {
+    return isDarkMode ? Colors.yellow : Colors.orange;
+  }
+
+  static Color getEraserColor(bool isDarkMode) {
+    return primaryRed;
+  }
+
+  static Color getConnectModeColor(bool isDarkMode) {
+    return isDarkMode ? Colors.white.withValues(alpha: 0.5) : Colors.black.withValues(alpha: 0.3);
+  }
+
+  // Action button colors
+  static Color getActionButtonBorder(bool isDarkMode) {
+    return isDarkMode ? Colors.white70 : Colors.white;
+  }
+
+  // Mode indicator colors
+  static Color getModeIndicatorBackground(bool isDarkMode, {bool isError = false}) {
+    if (isError) {
+      return isDarkMode ? primaryRed.withValues(alpha: 0.9) : primaryRed.withValues(alpha: 0.8);
+    }
+    return isDarkMode ? Colors.grey.withValues(alpha: 0.9) : Colors.grey.withValues(alpha: 0.8);
+  }
+
+  // Info panel colors
+  static Color getInfoPanelHeaderBackground(bool isDarkMode) {
+    return isDarkMode ? Colors.black.withValues(alpha: 0.3) : Color(0xFFE3F2FD);
+  }
+
+  static Color getInfoPanelFieldBackground(bool isDarkMode) {
+    return isDarkMode ? Colors.black.withValues(alpha: 0.2) : Color(0xFFF5F5F5);
+  }
+
+  // Shadow colors
+  static List<BoxShadow> getNodeShadow(bool isDarkMode, double scale) {
+    return [
+      BoxShadow(
+        color: isDarkMode
+          ? Colors.black.withValues(alpha: 0.3)
+          : Colors.black.withValues(alpha: 0.15),
+        blurRadius: 8.0 * scale,
+        offset: const Offset(0, 4),
+      ),
+    ];
+  }
+
+  // Icon selector dialog
+  static Color getIconSelectorBackground(bool isDarkMode) {
+    return isDarkMode ? darkSurface : lightSurface;
+  }
+
+  static Color getIconSelectorHeaderBackground(bool isDarkMode) {
+    return isDarkMode ? Colors.black.withValues(alpha: 0.3) : Color(0xFFE8EAF6);
+  }
+}

--- a/lib/widgets/connection_painter.dart
+++ b/lib/widgets/connection_painter.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/connection.dart';
 import '../models/todo_node.dart';
+import '../theme/app_theme.dart';
 import 'dart:math' as math;
 
 class ConnectionPainter extends CustomPainter {
@@ -13,6 +14,7 @@ class ConnectionPainter extends CustomPainter {
   final double animationValue;
   final String? hoveredConnectionId;
   final VoidCallback? onConnectionDelete;
+  final bool isDarkMode;
 
   ConnectionPainter({
     required this.connections,
@@ -24,6 +26,7 @@ class ConnectionPainter extends CustomPainter {
     this.animationValue = 0.0,
     this.hoveredConnectionId,
     this.onConnectionDelete,
+    required this.isDarkMode,
   });
 
   @override
@@ -50,10 +53,11 @@ class ConnectionPainter extends CustomPainter {
 
     // Draw pulsing circle around selected node
     final pulseAlpha = 0.8 * (0.5 + 0.5 * math.sin(animationValue * 6));
+    final selectionColor = AppTheme.getSelectionColor(isDarkMode);
     final pulsePaint = Paint()
       ..style = PaintingStyle.stroke
       ..strokeWidth = 3.0
-      ..color = Colors.yellow.withValues(alpha: pulseAlpha);
+      ..color = selectionColor.withValues(alpha: pulseAlpha);
 
     canvas.drawCircle(
       fromPos,
@@ -66,9 +70,10 @@ class ConnectionPainter extends CustomPainter {
   }
 
   void _drawAnimatedArrows(Canvas canvas, Offset center, double radius) {
+    final selectionColor = AppTheme.getSelectionColor(isDarkMode);
     final arrowPaint = Paint()
       ..style = PaintingStyle.fill
-      ..color = Colors.yellow.withValues(alpha: 0.7);
+      ..color = selectionColor.withValues(alpha: 0.7);
 
     // Draw 8 arrows in a circle
     for (int i = 0; i < 8; i++) {
@@ -147,14 +152,14 @@ class ConnectionPainter extends CustomPainter {
         ..style = PaintingStyle.stroke
         ..strokeWidth = (8.0 * scale).clamp(4.0, 16.0)
         ..strokeCap = StrokeCap.round
-        ..color = const Color(0xFF4CAF50).withValues(alpha: 0.3);
+        ..color = AppTheme.primaryGreen.withValues(alpha: 0.3);
 
       canvas.drawLine(connectionPoints.from, connectionPoints.to, glowPaint);
     } else if (connection.isCharging) {
       _drawChargingConnection(canvas, connectionPoints, connection, scale);
       return;
     } else {
-      paint.color = Colors.white.withValues(alpha: 0.6);
+      paint.color = AppTheme.getConnectionColor(isDarkMode);
     }
 
     // Draw the main connection line
@@ -180,7 +185,7 @@ class ConnectionPainter extends CustomPainter {
       ..style = PaintingStyle.stroke
       ..strokeWidth = (3.0 * scale).clamp(1.0, 6.0)
       ..strokeCap = StrokeCap.round
-      ..color = Colors.white.withValues(alpha: 0.4);
+      ..color = AppTheme.getConnectionColor(isDarkMode).withValues(alpha: 0.4);
 
     canvas.drawLine(points.from, points.to, basePaint);
 
@@ -213,13 +218,13 @@ class ConnectionPainter extends CustomPainter {
         ..style = PaintingStyle.stroke
         ..strokeWidth = (4.0 * scale).clamp(2.0, 8.0)
         ..strokeCap = StrokeCap.round
-        ..color = const Color(0xFF4CAF50);
+        ..color = AppTheme.primaryGreen;
 
       final glowPaint = Paint()
         ..style = PaintingStyle.stroke
         ..strokeWidth = (8.0 * scale).clamp(4.0, 16.0)
         ..strokeCap = StrokeCap.round
-        ..color = const Color(0xFF4CAF50).withValues(alpha: 0.5);
+        ..color = AppTheme.primaryGreen.withValues(alpha: 0.5);
 
       if (connection.chargingProgress > 0) {
         canvas.drawLine(chargingStartPoint, chargingEndPoint, glowPaint);
@@ -244,9 +249,7 @@ class ConnectionPainter extends CustomPainter {
   ) {
     final dotPaint = Paint()
       ..style = PaintingStyle.fill
-      ..color = isGreen
-          ? const Color(0xFF4CAF50)
-          : Colors.white.withValues(alpha: 0.8);
+      ..color = AppTheme.getConnectionDotColor(isDarkMode, isGolden: isGreen);
 
     final dotRadius = (4.0 * scale).clamp(2.0, 8.0);
     canvas.drawCircle(points.from, dotRadius, dotPaint);
@@ -332,7 +335,8 @@ class ConnectionPainter extends CustomPainter {
         isConnectMode != oldDelegate.isConnectMode ||
         selectedNodeForConnection != oldDelegate.selectedNodeForConnection ||
         animationValue != oldDelegate.animationValue ||
-        hoveredConnectionId != oldDelegate.hoveredConnectionId;
+        hoveredConnectionId != oldDelegate.hoveredConnectionId ||
+        isDarkMode != oldDelegate.isDarkMode;
   }
 }
 

--- a/lib/widgets/icon_selector_widget.dart
+++ b/lib/widgets/icon_selector_widget.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:provider/provider.dart';
+import '../providers/canvas_provider.dart';
+import '../theme/app_theme.dart';
 
 class IconSelectorWidget extends StatefulWidget {
   final String? currentIcon;
@@ -591,6 +594,9 @@ class _IconSelectorWidgetState extends State<IconSelectorWidget> {
 
   @override
   Widget build(BuildContext context) {
+    final provider = context.watch<CanvasProvider>();
+    final isDarkMode = provider.isDarkMode;
+
     return Container(
       height: 400,
       padding: const EdgeInsets.all(16),
@@ -601,27 +607,27 @@ class _IconSelectorWidgetState extends State<IconSelectorWidget> {
             'Select Icon',
             style: Theme.of(context).textTheme.titleLarge?.copyWith(
               fontWeight: FontWeight.bold,
-              color: Colors.white,
+              color: AppTheme.getTextColor(isDarkMode),
             ),
           ),
           const SizedBox(height: 16),
-          
+
           // Search bar
           TextField(
             controller: _searchController,
-            style: const TextStyle(color: Colors.white),
+            style: TextStyle(color: AppTheme.getTextColor(isDarkMode)),
             decoration: InputDecoration(
               hintText: 'Search icons (e.g., target, code, heart)...',
-              hintStyle: TextStyle(color: Colors.grey[400]),
-              prefixIcon: const Icon(Icons.search, color: Colors.white),
-              border: const OutlineInputBorder(
-                borderSide: BorderSide(color: Colors.white),
+              hintStyle: TextStyle(color: AppTheme.getTextHintColor(isDarkMode)),
+              prefixIcon: Icon(Icons.search, color: AppTheme.getTextSecondaryColor(isDarkMode)),
+              border: OutlineInputBorder(
+                borderSide: BorderSide(color: AppTheme.getBorderColor(isDarkMode)),
               ),
               enabledBorder: OutlineInputBorder(
-                borderSide: BorderSide(color: Colors.grey[600]!),
+                borderSide: BorderSide(color: AppTheme.getBorderColor(isDarkMode)),
               ),
-              focusedBorder: const OutlineInputBorder(
-                borderSide: BorderSide(color: Colors.white, width: 2),
+              focusedBorder: OutlineInputBorder(
+                borderSide: BorderSide(color: AppTheme.primaryBlue, width: 2),
               ),
               contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
             ),
@@ -648,13 +654,13 @@ class _IconSelectorWidgetState extends State<IconSelectorWidget> {
                   onTap: () => widget.onIconSelected(icon),
                   child: Container(
                     decoration: BoxDecoration(
-                      color: isSelected 
-                        ? Theme.of(context).primaryColor.withValues(alpha: 0.2)
-                        : Colors.grey.withValues(alpha: 0.1),
+                      color: isSelected
+                        ? AppTheme.primaryBlue.withValues(alpha: isDarkMode ? 0.2 : 0.1)
+                        : (isDarkMode ? Colors.grey.withValues(alpha: 0.1) : AppTheme.lightSurfaceLight),
                       border: Border.all(
-                        color: isSelected 
-                          ? Theme.of(context).primaryColor
-                          : Colors.grey.withValues(alpha: 0.3),
+                        color: isSelected
+                          ? AppTheme.primaryBlue
+                          : AppTheme.getBorderColor(isDarkMode),
                         width: isSelected ? 2 : 1,
                       ),
                       borderRadius: BorderRadius.circular(8),
@@ -663,9 +669,9 @@ class _IconSelectorWidgetState extends State<IconSelectorWidget> {
                       child: Icon(
                         _getPhosphorIcon(icon),
                         size: 24,
-                        color: isSelected 
-                          ? Theme.of(context).primaryColor
-                          : Colors.white,
+                        color: isSelected
+                          ? AppTheme.primaryBlue
+                          : AppTheme.getTextColor(isDarkMode),
                       ),
                     ),
                   ),
@@ -676,12 +682,12 @@ class _IconSelectorWidgetState extends State<IconSelectorWidget> {
           
           // Footer info
           if (_filteredIcons.isEmpty)
-            const Padding(
+            Padding(
               padding: EdgeInsets.all(16),
               child: Center(
                 child: Text(
                   'No icons found. Try a different search term.',
-                  style: TextStyle(color: Colors.white70),
+                  style: TextStyle(color: AppTheme.getTextSecondaryColor(isDarkMode)),
                 ),
               ),
             ),

--- a/lib/widgets/info_panel_widget.dart
+++ b/lib/widgets/info_panel_widget.dart
@@ -454,22 +454,22 @@ class _InfoPanelWidgetState extends State<InfoPanelWidget> {
                             child: Container(
                               padding: const EdgeInsets.all(8),
                               decoration: BoxDecoration(
-                                color: AppTheme.getInfoPanelFieldBackground(provider.isDarkMode),
+                                color: AppTheme.getNodeBackgroundColor(_selectedColor, provider.isDarkMode),
                                 borderRadius: BorderRadius.circular(8),
-                                border: Border.all(color: AppTheme.getBorderColor(provider.isDarkMode)),
+                                border: Border.all(color: _selectedColor.withValues(alpha: 0.5)),
                               ),
                               child: Row(
                                 mainAxisSize: MainAxisSize.min,
                                 children: [
                                   Icon(
                                     _getPhosphorIcon(_selectedIcon),
-                                    size: 20,
-                                    color: AppTheme.getTextColor(provider.isDarkMode),
+                                    size: 24,
+                                    color: AppTheme.getNodeIconColor(provider.isDarkMode),
                                   ),
                                   const SizedBox(width: 4),
                                   Icon(
                                     Icons.edit,
-                                    size: 16,
+                                    size: 14,
                                     color: AppTheme.getTextSecondaryColor(provider.isDarkMode),
                                   ),
                                 ],

--- a/lib/widgets/info_panel_widget.dart
+++ b/lib/widgets/info_panel_widget.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 import '../models/todo_node.dart';
 import '../providers/canvas_provider.dart';
+import '../theme/app_theme.dart';
 import 'icon_selector_widget.dart';
 
 class InfoPanelWidget extends StatefulWidget {
@@ -261,10 +262,11 @@ class _InfoPanelWidgetState extends State<InfoPanelWidget> {
   }
 
   void _showIconSelector() {
+    final provider = context.read<CanvasProvider>();
     showDialog(
       context: context,
       builder: (context) => Dialog(
-        backgroundColor: const Color(0xFF2D2D2D),
+        backgroundColor: AppTheme.getIconSelectorBackground(provider.isDarkMode),
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(12),
         ),
@@ -345,9 +347,9 @@ class _InfoPanelWidgetState extends State<InfoPanelWidget> {
           width: panelWidth,
           height: panelHeight,
           decoration: BoxDecoration(
-            color: const Color(0xFF2D2D2D),
+            color: AppTheme.getSurfaceColor(provider.isDarkMode),
             borderRadius: BorderRadius.circular(12),
-            border: Border.all(color: Colors.white.withValues(alpha: 0.2)),
+            border: Border.all(color: AppTheme.getBorderColor(provider.isDarkMode)),
           ),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -356,14 +358,14 @@ class _InfoPanelWidgetState extends State<InfoPanelWidget> {
               Container(
                 padding: const EdgeInsets.all(16),
                 decoration: BoxDecoration(
-                  color: Colors.black.withValues(alpha: 0.3),
+                  color: AppTheme.getInfoPanelHeaderBackground(provider.isDarkMode),
                   borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
                 ),
                 child: Row(
                   children: [
                     Icon(
                       Icons.info_outline,
-                      color: Colors.white.withValues(alpha: 0.9),
+                      color: AppTheme.getTextColor(provider.isDarkMode),
                       size: 20,
                     ),
                     const SizedBox(width: 8),
@@ -371,7 +373,7 @@ class _InfoPanelWidgetState extends State<InfoPanelWidget> {
                       child: Text(
                         widget.node.text.isEmpty ? 'New Task' : widget.node.text,
                         style: TextStyle(
-                          color: Colors.white.withValues(alpha: 0.9),
+                          color: AppTheme.getTextColor(provider.isDarkMode),
                           fontSize: 16,
                           fontWeight: FontWeight.bold,
                         ),
@@ -383,7 +385,7 @@ class _InfoPanelWidgetState extends State<InfoPanelWidget> {
                       onPressed: () => provider.hideNodeInfo(),
                       icon: const Icon(Icons.close),
                       iconSize: 18,
-                      color: Colors.white.withValues(alpha: 0.7),
+                      color: AppTheme.getTextSecondaryColor(provider.isDarkMode),
                       padding: EdgeInsets.zero,
                       constraints: const BoxConstraints(minWidth: 24, minHeight: 24),
                     ),
@@ -402,7 +404,7 @@ class _InfoPanelWidgetState extends State<InfoPanelWidget> {
                       Text(
                         'Title:',
                         style: TextStyle(
-                          color: Colors.white.withValues(alpha: 0.8),
+                          color: AppTheme.getTextSecondaryColor(provider.isDarkMode),
                           fontSize: 14,
                           fontWeight: FontWeight.w500,
                         ),
@@ -410,27 +412,27 @@ class _InfoPanelWidgetState extends State<InfoPanelWidget> {
                       const SizedBox(height: 4),
                       TextField(
                         controller: _titleController,
-                        style: const TextStyle(
-                          color: Colors.white,
+                        style: TextStyle(
+                          color: AppTheme.getTextColor(provider.isDarkMode),
                           fontSize: 14,
                         ),
                         decoration: InputDecoration(
                           hintText: 'Enter task title...',
                           hintStyle: TextStyle(
-                            color: Colors.white.withValues(alpha: 0.4),
+                            color: AppTheme.getTextHintColor(provider.isDarkMode),
                             fontSize: 14,
                           ),
                           border: OutlineInputBorder(
                             borderRadius: BorderRadius.circular(8),
-                            borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.3)),
+                            borderSide: BorderSide(color: AppTheme.getBorderColor(provider.isDarkMode)),
                           ),
                           focusedBorder: OutlineInputBorder(
                             borderRadius: BorderRadius.circular(8),
-                            borderSide: const BorderSide(color: Colors.blue, width: 2),
+                            borderSide: BorderSide(color: AppTheme.primaryBlue, width: 2),
                           ),
                           contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                           filled: true,
-                          fillColor: Colors.black.withValues(alpha: 0.2),
+                          fillColor: AppTheme.getInfoPanelFieldBackground(provider.isDarkMode),
                         ),
                       ),
                       const SizedBox(height: 16),
@@ -441,7 +443,7 @@ class _InfoPanelWidgetState extends State<InfoPanelWidget> {
                           Text(
                             'Icon:',
                             style: TextStyle(
-                              color: Colors.white.withValues(alpha: 0.8),
+                              color: AppTheme.getTextSecondaryColor(provider.isDarkMode),
                               fontSize: 14,
                               fontWeight: FontWeight.w500,
                             ),
@@ -452,9 +454,9 @@ class _InfoPanelWidgetState extends State<InfoPanelWidget> {
                             child: Container(
                               padding: const EdgeInsets.all(8),
                               decoration: BoxDecoration(
-                                color: Colors.black.withValues(alpha: 0.2),
+                                color: AppTheme.getInfoPanelFieldBackground(provider.isDarkMode),
                                 borderRadius: BorderRadius.circular(8),
-                                border: Border.all(color: Colors.white.withValues(alpha: 0.3)),
+                                border: Border.all(color: AppTheme.getBorderColor(provider.isDarkMode)),
                               ),
                               child: Row(
                                 mainAxisSize: MainAxisSize.min,
@@ -462,13 +464,13 @@ class _InfoPanelWidgetState extends State<InfoPanelWidget> {
                                   Icon(
                                     _getPhosphorIcon(_selectedIcon),
                                     size: 20,
-                                    color: Colors.white,
+                                    color: AppTheme.getTextColor(provider.isDarkMode),
                                   ),
                                   const SizedBox(width: 4),
                                   Icon(
                                     Icons.edit,
                                     size: 16,
-                                    color: Colors.white.withValues(alpha: 0.6),
+                                    color: AppTheme.getTextSecondaryColor(provider.isDarkMode),
                                   ),
                                 ],
                               ),
@@ -482,7 +484,7 @@ class _InfoPanelWidgetState extends State<InfoPanelWidget> {
                       Text(
                         'Description:',
                         style: TextStyle(
-                          color: Colors.white.withValues(alpha: 0.8),
+                          color: AppTheme.getTextSecondaryColor(provider.isDarkMode),
                           fontSize: 14,
                           fontWeight: FontWeight.w500,
                         ),
@@ -491,27 +493,27 @@ class _InfoPanelWidgetState extends State<InfoPanelWidget> {
                       TextField(
                         controller: _descriptionController,
                         maxLines: 4,
-                        style: const TextStyle(
-                          color: Colors.white,
+                        style: TextStyle(
+                          color: AppTheme.getTextColor(provider.isDarkMode),
                           fontSize: 14,
                         ),
                         decoration: InputDecoration(
                           hintText: 'Add a description...',
                           hintStyle: TextStyle(
-                            color: Colors.white.withValues(alpha: 0.4),
+                            color: AppTheme.getTextHintColor(provider.isDarkMode),
                             fontSize: 14,
                           ),
                           border: OutlineInputBorder(
                             borderRadius: BorderRadius.circular(8),
-                            borderSide: BorderSide(color: Colors.white.withValues(alpha: 0.3)),
+                            borderSide: BorderSide(color: AppTheme.getBorderColor(provider.isDarkMode)),
                           ),
                           focusedBorder: OutlineInputBorder(
                             borderRadius: BorderRadius.circular(8),
-                            borderSide: const BorderSide(color: Colors.blue, width: 2),
+                            borderSide: BorderSide(color: AppTheme.primaryBlue, width: 2),
                           ),
                           contentPadding: const EdgeInsets.all(10),
                           filled: true,
-                          fillColor: Colors.black.withValues(alpha: 0.2),
+                          fillColor: AppTheme.getInfoPanelFieldBackground(provider.isDarkMode),
                         ),
                       ),
                       const SizedBox(height: 12),
@@ -520,7 +522,7 @@ class _InfoPanelWidgetState extends State<InfoPanelWidget> {
                       Text(
                         'Color:',
                         style: TextStyle(
-                          color: Colors.white.withValues(alpha: 0.8),
+                          color: AppTheme.getTextSecondaryColor(provider.isDarkMode),
                           fontSize: 14,
                           fontWeight: FontWeight.w500,
                         ),
@@ -577,7 +579,7 @@ class _InfoPanelWidgetState extends State<InfoPanelWidget> {
               Container(
                 padding: const EdgeInsets.all(8),
                 decoration: BoxDecoration(
-                  color: Colors.black.withValues(alpha: 0.1),
+                  color: AppTheme.getInfoPanelHeaderBackground(provider.isDarkMode).withValues(alpha: 0.3),
                   borderRadius: const BorderRadius.vertical(bottom: Radius.circular(12)),
                 ),
                 child: Row(
@@ -605,7 +607,7 @@ class _InfoPanelWidgetState extends State<InfoPanelWidget> {
                       child: Text(
                         'Cancel',
                         style: TextStyle(
-                          color: Colors.white.withValues(alpha: 0.7),
+                          color: AppTheme.getTextSecondaryColor(provider.isDarkMode),
                           fontSize: 13,
                         ),
                       ),

--- a/lib/widgets/todo_node_widget.dart
+++ b/lib/widgets/todo_node_widget.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 import '../models/todo_node.dart';
 import '../providers/canvas_provider.dart';
+import '../theme/app_theme.dart';
 
 class TodoNodeWidget extends StatefulWidget {
   final TodoNode node;
@@ -494,11 +495,11 @@ class _TodoNodeWidgetState extends State<TodoNodeWidget>
     final provider = context.watch<CanvasProvider>();
 
     if (provider.selectedNodeForConnection == widget.node.id) {
-      return Colors.yellow;
+      return AppTheme.getSelectionColor(provider.isDarkMode);
     } else if (provider.isEraserMode) {
-      return Colors.red;
+      return AppTheme.getEraserColor(provider.isDarkMode);
     } else if (provider.isConnectMode) {
-      return Colors.white.withValues(alpha: 0.5);
+      return AppTheme.getConnectModeColor(provider.isDarkMode);
     } else {
       return Colors.transparent;
     }
@@ -519,13 +520,8 @@ class _TodoNodeWidgetState extends State<TodoNodeWidget>
   }
 
   List<BoxShadow> _buildShadows(double scale) {
-    List<BoxShadow> shadows = [
-      BoxShadow(
-        color: Colors.black.withValues(alpha: 0.3),
-        blurRadius: 8.0 * scale,
-        offset: const Offset(0, 4),
-      ),
-    ];
+    final provider = context.watch<CanvasProvider>();
+    List<BoxShadow> shadows = AppTheme.getNodeShadow(provider.isDarkMode, scale);
 
     // Add dramatic glow effects when completed
     if (widget.node.isCompleted) {
@@ -676,33 +672,35 @@ class _TodoNodeWidgetState extends State<TodoNodeWidget>
             curve: Curves.easeOut,
             child: GestureDetector(
               onTap: onTap,
-              child: Container(
-                width: buttonSize,
-                height: buttonSize,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: color.withValues(alpha: 0.9),
-                  border: Border.all(
-                    color: Colors.white.withValues(alpha: 0.8),
-                    width: 2.0,
+              child: Consumer<CanvasProvider>(
+                builder: (context, provider, child) => Container(
+                  width: buttonSize,
+                  height: buttonSize,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: color.withValues(alpha: 0.9),
+                    border: Border.all(
+                      color: AppTheme.getActionButtonBorder(provider.isDarkMode),
+                      width: 2.0,
+                    ),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withValues(alpha: 0.3),
+                        blurRadius: 8.0,
+                        offset: const Offset(0, 2),
+                      ),
+                      BoxShadow(
+                        color: color.withValues(alpha: 0.3),
+                        blurRadius: 12.0,
+                        spreadRadius: 2.0,
+                      ),
+                    ],
                   ),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withValues(alpha: 0.3),
-                      blurRadius: 8.0,
-                      offset: const Offset(0, 2),
-                    ),
-                    BoxShadow(
-                      color: color.withValues(alpha: 0.3),
-                      blurRadius: 12.0,
-                      spreadRadius: 2.0,
-                    ),
-                  ],
-                ),
-                child: Icon(
-                  icon,
-                  color: Colors.white,
-                  size: buttonSize * 0.5,
+                  child: Icon(
+                    icon,
+                    color: Colors.white,
+                    size: buttonSize * 0.5,
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
- Add theme mode state management to CanvasProvider
- Create AppTheme class with comprehensive light and dark color schemes
- Update all widgets to use theme-aware colors:
  - Main canvas and grid
  - Nodes and connections
  - Info panel
  - Icon selector
  - Mode indicators
- Add theme toggle button to floating action buttons
- Light mode features very light, minimal colors as requested
- All UI elements now respect the selected theme